### PR TITLE
Avoid duplicate linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         cache: npm
     - name: install dependencies
       run: npm ci
-    - run: npm test
+    - run: npm run test:jest
 
   release-it-compat:
     name: "release-it@${{ matrix.release-it-version }}"
@@ -56,4 +56,4 @@ jobs:
     - name: install dependencies
       run: npm ci
     - run: npm install --saveDev release-it@${{ matrix.release-it-version }}
-    - run: npm test
+    - run: npm run test:jest


### PR DESCRIPTION
The `lint` job validates our linting setup, so the other jobs only need to run `test:jest`.

Note: we want to keep `npm test` running linting so that contributors have a normal experience of knowing when a given change is "good" or "bad".
