### PR TITLE
Update Node requirement to v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4.1.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "vitest": "^0.33.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">=20"
       },
       "peerDependencies": {
         "release-it": "^14.0.0 || ^15.1.3 || ^16.0.0 || ^17.0.0"

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "release-it": "^14.0.0 || ^15.1.3 || ^16.0.0 || ^17.0.0"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">=20"
   },
   "volta": {
-    "node": "18.20.3"
+    "node": "20.12.2"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary
- set minimum Node to v20 in package.json and package-lock.json
- pin Volta to latest Node v20
- run CI on Node v20, 22, and 24

## Testing
- `npm test` *(fails: npm-run-all not found)*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6851ec1cb2a08325b703a28d32a1d655