### PR TITLE
Ensure file launched via `launchEditor` config is treated as Markdown syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ export default class LernaChangelogGeneratorPlugin extends Plugin {
       return changelog;
     }
 
-    let tmpFile = tmp.fileSync().name;
+    let tmpFile = tmp.fileSync({ postfix: '.md' }).name;
     fs.writeFileSync(tmpFile, changelog, { encoding: 'utf-8' });
 
     await this._launchEditor(tmpFile);

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -244,6 +244,18 @@ describe('@release-it-plugins/lerna-changelog', () => {
     expect(fs.readFileSync(output, 'utf-8')).toEqual(`args: ${plugin.launchedTmpFile}`);
   });
 
+  test('launches a markdown file for editing', async () => {
+    let infile = tmp.fileSync().name;
+
+    let { editor } = await buildEditorCommand();
+
+    let plugin = await buildPlugin({ infile, launchEditor: `${editor} \${file}` });
+
+    await runTasks(plugin);
+
+    expect(plugin.launchedTmpFile.endsWith('.md')).toBe(true);
+  });
+
   test('does not launch the editor for dry-run', async () => {
     let infile = tmp.fileSync().name;
 


### PR DESCRIPTION
## Summary
- ensure the temp file launched for editing uses a `.md` suffix
- document that the editor gets a markdown temp file
- test the file extension

## Testing
- `npm test`

Fixes #309 